### PR TITLE
Use 'language-code' from deform. 

### DIFF
--- a/kotti_tinymce/locale/de/LC_MESSAGES/kotti_tinymce.po
+++ b/kotti_tinymce/locale/de/LC_MESSAGES/kotti_tinymce.po
@@ -59,8 +59,3 @@ msgstr "Beschreibung"
 #: kotti_tinymce/templates/kottibrowser.pt:95
 msgid "File"
 msgstr "Datei"
-
-#: kotti_tinymce/templates/deform/richtext.pt:41
-msgid "en"
-msgstr "de"
-

--- a/kotti_tinymce/locale/kotti_tinymce.pot
+++ b/kotti_tinymce/locale/kotti_tinymce.pot
@@ -59,8 +59,3 @@ msgstr ""
 #: kotti_tinymce/templates/kottibrowser.pt:95
 msgid "File"
 msgstr ""
-
-#: kotti_tinymce/templates/deform/richtext.pt:41
-msgid "en"
-msgstr ""
-

--- a/kotti_tinymce/templates/deform/richtext.pt
+++ b/kotti_tinymce/templates/deform/richtext.pt
@@ -1,7 +1,6 @@
 <div xmlns:i18n="http://xml.zope.org/namespaces/i18n"
      xmlns:tal="http://xml.zope.org/namespaces/tal"
-     tal:omit-tag=""
-     i18n:domain="kotti_tinymce">
+     tal:omit-tag="">
 <textarea id="${field.oid}" name="${field.name}" class='tinymce' tal:content="structure cstruct" />
 <span id="${field.oid}-preload" class="tinymce-preload" tal:content="structure cstruct" />
 <script language="javascript" type="text/javascript">
@@ -38,7 +37,7 @@
                         external_image_list_url : 'external_image_list',
                         external_link_list_url : 'external_link_list',
                         file_browser_callback : 'kottibrowser',
-                        language: '<div i18n:translate="" tal:omit-tag="">en</div>'
+                        language: '<tal:block i18n:domain="deform" i18n:translate="language-code">en</tal:block>'
                     });
                     jqoid_preload.unbind('click');
                 });


### PR DESCRIPTION
(This will automatically make things work for 'ja', 'nl', 'pt', too.)
